### PR TITLE
Update 1.vue-instantsearch.md

### DIFF
--- a/docs/content/2.advanced/1.vue-instantsearch.md
+++ b/docs/content/2.advanced/1.vue-instantsearch.md
@@ -32,7 +32,7 @@ Next, let's create `indexName` variable, call `useAlgolia` composable in page.vu
 <script lang="ts" setup>
 const indexName = 'test_index' 
 const algolia = useAlgoliaRef()
-import { AisInstantSearch, AisSearchBox, AisHits } from 'vue-instantsearch/vue3/es'
+import { AisInstantSearch, AisSearchBox, AisHits } from 'vue-instantsearch/vue3/es/index.js'
 </script>
 ```
 


### PR DESCRIPTION
since RC9 `autoImports:dirs` is deprecated on some environments like Vercel the build fails with the old import statement. This version should work fine on all envs i tested.

Example Error:

```
2022-09-22T08:38:15.798Z	c0351ce2-5adc-45af-b96d-54647a71d8e6	ERROR	[nuxt] [request error] [unhandled] [500] Directory import '/var/task/node_modules/vue-instantsearch/vue3/es' is not supported resolving ES modules imported from /var/task/chunks/app/server.mjs
Did you mean to import vue-instantsearch/vue3/es/index.js?
  at new NodeError (node:internal/errors:372:5)  
  at finalizeResolution (node:internal/modules/esm/resolve:433:17)  
  at moduleResolve (node:internal/modules/esm/resolve:1009:10)  
  at defaultResolve (node:internal/modules/esm/resolve:1218:11)  
  at ESMLoader.resolve (node:internal/modules/esm/loader:580:30)  
  at ESMLoader.getModuleJob (node:internal/modules/esm/loader:294:18)  
  at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:80:40)  
  at link (node:internal/modules/esm/module_job:78:36)
```

