### PR TITLE
fix(docsearch): do not import directly from `docsearch`

### DIFF
--- a/src/runtime/components/AlgoliaDocSearch.vue
+++ b/src/runtime/components/AlgoliaDocSearch.vue
@@ -7,8 +7,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue'
 import { withoutTrailingSlash } from 'ufo'
-import { DocSearchProps, type docsearch as docsearchFunc } from 'docsearch'
-import type { DocSearchTranslations } from '@docsearch/react'
+import type { DocSearchTranslations, DocSearchProps } from '@docsearch/react'
 import type { HitComponentFunc, ModuleBaseOptions, SearchOptions } from '../../types'
 // @ts-ignore - These are Nuxt3 aliases
 import { useRuntimeConfig, useRoute, useRouter, onMounted, watch } from '#imports'
@@ -144,7 +143,9 @@ const withoutBaseUrl = (url: string) => {
   return url
 }
 
-const importDocSearchAtRuntime = async (): Promise<typeof docsearchFunc> => {
+type DocSearchFunc = (props: DocSearchProps & {container: HTMLElement | string}) => void
+
+const importDocSearchAtRuntime = async (): Promise<DocSearchFunc> => {
   const [docsearch] = await Promise.all([
     // @ts-ignore
     import(/* webpackChunkName: "docsearch" */ '@docsearch/js'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Resolves: #185

I don't know what's up with importing directly from `docsearch` (especially because it works within this repo), but avoiding it is easy.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
