### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/docs/content/2.advanced/1.vue-instantsearch.md
+++ b/docs/content/2.advanced/1.vue-instantsearch.md
@@ -80,7 +80,7 @@ onBeforeMount(() => {
 })
 
 const { data: algoliaState } = await useAsyncData('algolia-state', async () => {
-    if (process.server) {
+    if (import.meta.server) {
         const nuxtApp = useNuxtApp();
         nuxtApp.$algolia.transporter.requester = (
             await import('@algolia/requester-node-http').then(

--- a/src/runtime/components/AlgoliaDocSearch.vue
+++ b/src/runtime/components/AlgoliaDocSearch.vue
@@ -150,7 +150,7 @@ const importDocSearchAtRuntime = async (): Promise<DocSearchFunc> => {
     // @ts-ignore
     import(/* webpackChunkName: "docsearch" */ '@docsearch/js'),
     // @ts-ignore
-    process.client && import(/* webpackChunkName: "docsearch" */ '@docsearch/css')
+    import.meta.client && import(/* webpackChunkName: "docsearch" */ '@docsearch/css')
   ])
 
   return docsearch.default
@@ -246,7 +246,7 @@ onMounted(async () => {
   await initialize()
 })
 
-if (process.client) {
+if (import.meta.client) {
   watch(props, async () => {
     await initialize()
   })

--- a/src/runtime/composables/useAlgoliaSearch.ts
+++ b/src/runtime/composables/useAlgoliaSearch.ts
@@ -25,7 +25,7 @@ export function useAlgoliaSearch (indexName?: string) {
   const result = useState(`${index}-search-result`, () => null)
 
   const search = async ({ query, requestOptions }: SearchParams) => {
-    if (process.server) {
+    if (import.meta.server) {
       const nuxtApp = useNuxtApp()
       if (config.public.algolia.useFetch) {
         nuxtApp.$algolia.transporter.requester = (await import("@algolia/requester-fetch").then((lib) => lib.default || lib)).createFetchRequester();

--- a/src/runtime/composables/useAsyncAlgoliaSearch.ts
+++ b/src/runtime/composables/useAsyncAlgoliaSearch.ts
@@ -14,7 +14,7 @@ export async function useAsyncAlgoliaSearch ({ query, requestOptions, indexName,
   const algoliaIndex = useAlgoliaInitIndex(index)
 
   const result = await useAsyncData(`${index}-async-search-result-${key ?? ''}`, async () => {
-    if (process.server) {
+    if (import.meta.server) {
       const nuxtApp = useNuxtApp()
       if (config.public.algolia.useFetch) {
         nuxtApp.$algolia.transporter.requester = (await import('@algolia/requester-fetch').then((lib) => lib.default || lib)).createFetchRequester();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
