### PR TITLE
feat: added fetch requester for ssr reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@algolia/cache-in-memory": "^4.14.2",
     "@algolia/recommend": "^4.12.2",
-    "@algolia/requester-fetch": "^4.20.0",
+    "@algolia/requester-fetch": "^4.23.2",
     "@nuxt/kit": "^3.7.0",
     "algoliasearch": "^4.11.0",
     "instantsearch.css": "^7.4.5",

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,6 +1,7 @@
 import { SearchClient } from 'algoliasearch/lite'
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 import { createInMemoryCache } from '@algolia/cache-in-memory';
+import { createFetchRequester } from '@algolia/requester-fetch';
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const { applicationId, apiKey, lite, recommend, cache } = useRuntimeConfig().public.algolia
@@ -11,7 +12,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     ? await import('algoliasearch/dist/algoliasearch-lite.esm.browser').then(lib => lib.default || lib)
     : await import('algoliasearch/dist/algoliasearch.esm.browser').then(lib => lib.default || lib)
 
-  const algoliaSearchClient: SearchClient = cache ? algoliasearch(applicationId, apiKey, { responsesCache: createInMemoryCache(), requestsCache: createInMemoryCache({ serializable: false }), }) : algoliasearch(applicationId, apiKey)
+  const algoliaSearchClient: SearchClient = cache ? algoliasearch(applicationId, apiKey, { responsesCache: createInMemoryCache(), requestsCache: createInMemoryCache({ serializable: false }), requester: createFetchRequester() }) : algoliasearch(applicationId, apiKey, { requester: createFetchRequester() })
 
   nuxtApp.provide('algolia', algoliaSearchClient)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,12 +144,17 @@
   resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.20.0.tgz#65694b2263a8712b4360fef18680528ffd435b5c"
   integrity sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==
 
-"@algolia/requester-fetch@^4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-fetch/-/requester-fetch-4.20.0.tgz#e32e1b501d2c21b37d3077d0d17cc9acb78c2d86"
-  integrity sha512-VVWlS/vIGBEFomjCig0lyY4kUVEHH2mj1PJlNOC9VSyLbJ7/fIxslFChq6kEh2RUqGs4ju6h5kdS+Mis9D2Vxg==
+"@algolia/requester-common@4.23.2":
+  version "4.23.2"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.23.2.tgz#9c2e5da4dc15e65f9b9bbe5bedb419cf23092ef1"
+  integrity sha512-3EfpBS0Hri0lGDB5H/BocLt7Vkop0bTTLVUBB844HH6tVycwShmsV6bDR7yXbQvFP1uNpgePRD3cdBCjeHmk6Q==
+
+"@algolia/requester-fetch@^4.23.2":
+  version "4.23.2"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-fetch/-/requester-fetch-4.23.2.tgz#fd66ab41cdbff288b9054a156a93f77b3aa67695"
+  integrity sha512-ScmojcmwqGJMbpoAcSuufePl3XAg5CF1/m+jiMLyj4us3O+q9Ao+Js9MWeXBMj6BUwmuHa3uYz0HsBcl+5UsgA==
   dependencies:
-    "@algolia/requester-common" "4.20.0"
+    "@algolia/requester-common" "4.23.2"
 
 "@algolia/requester-node-http@4.20.0":
   version "4.20.0"


### PR DESCRIPTION
Fixes https://github.com/atoms-studio/nuxt-swiftsearch/issues/1


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
useAlgoliaRef exports the esm/browser version of the algoliasearch client.
The browser version uses the browserXHRRequester, which doesn't work in node environments, while the non-esm package works both in client and in server environments because it automatically switches XMLHttpRequester and browserXHRRequester depending on the environment it's called within, and that's why algoliaclient works but useAlgoliaRef does not when passing it to swiftsearch.

Proposed fix is to ubiquitously use the fetch requester, which is a better "futuristic" (more contemporary) approach.

If this works for you I'm going to implement swiftsearch integration after.
